### PR TITLE
fix SIGSEGV at flame throughput

### DIFF
--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -33,7 +33,7 @@ find_path (dpdk_INCLUDE_DIR
   PATH_SUFFIXES
     dpdk)
 
-set(rte_libs
+set(rte_libs_required
     bus_pci
     bus_vdev
     cfgfile
@@ -49,6 +49,19 @@ set(rte_libs
     mempool_ring
     meter
     net
+    pci
+    rcu
+    ring
+    security
+    telemetry
+    timer
+    vhost
+)
+
+# PMDs are optional: distros often split or omit them (e.g. Arch does not
+# ship librte_net_af_xdp). Missing optional drivers only fail at runtime
+# if sanicdns is actually told to use them.
+set(rte_libs_optional
     net_af_xdp
     net_bnxt
     net_cxgbe
@@ -62,14 +75,9 @@ set(rte_libs
     net_ring
     net_sfc
     net_vmxnet3
-    pci
-    rcu
-    ring
-    security
-    telemetry
-    timer
-    vhost
 )
+
+set(rte_libs ${rte_libs_required} ${rte_libs_optional})
 
 # Only necessary when linking statically
 if (${BUILD_STATIC})
@@ -97,8 +105,10 @@ foreach (lib ${rte_libs})
     NAME rte_${lib}
     HINTS
       ${dpdk_PC_STATIC_LIBRARY_DIRS})
-  list (APPEND dpdk_REQUIRED
-    ${library_name})
+  list (FIND rte_libs_required ${lib} _is_required_idx)
+  if (NOT ${_is_required_idx} EQUAL -1)
+    list (APPEND dpdk_REQUIRED ${library_name})
+  endif ()
   list (APPEND dpdk_LIBRARIES
     ${library_name})
 

--- a/include/dns_packet_constructor.h
+++ b/include/dns_packet_constructor.h
@@ -249,8 +249,8 @@ inline char* DNSPacketConstructor::ConstructIpv6Hdr(char* buf, const in6_addr& s
 	ipv6_hdr->payload_len = rte_cpu_to_be_16(l4_len + sizeof(rte_ipv6_hdr));
 	ipv6_hdr->vtc_flow = rte_cpu_to_be_32(0);
 
-	memcpy(ipv6_hdr->src_addr, &src_addr, sizeof(in6_addr));
-	memcpy(ipv6_hdr->dst_addr, &dst_addr, sizeof(in6_addr));
+	memcpy(&ipv6_hdr->src_addr, &src_addr, sizeof(in6_addr));
+	memcpy(&ipv6_hdr->dst_addr, &dst_addr, sizeof(in6_addr));
 
 	return (char*) (ipv6_hdr + 1);
 }

--- a/src/dns_packet.cpp
+++ b/src/dns_packet.cpp
@@ -385,8 +385,8 @@ tl::expected<DNSPacket, DNSParseError> DNSPacket::init(
 		const rte_ipv6_hdr *ip_hdr =
 		    UNWRAP_OR_RETURN(AdvanceReader<rte_ipv6_hdr>(packet_bytes, reader));
 
-		ip_data.dst_ip = *reinterpret_cast<const In6Addr *>(ip_hdr->dst_addr);
-		ip_data.src_ip = *reinterpret_cast<const In6Addr *>(ip_hdr->src_addr);
+		ip_data.dst_ip = *reinterpret_cast<const In6Addr *>(&ip_hdr->dst_addr);
+		ip_data.src_ip = *reinterpret_cast<const In6Addr *>(&ip_hdr->src_addr);
 
 		if (ip_hdr->proto != IPPROTO_UDP)
 			return tl::unexpected(DNSParseError::IpHdrProtoErr);

--- a/src/dns_packet.cpp
+++ b/src/dns_packet.cpp
@@ -202,11 +202,13 @@ tl::expected<ResourceRecord, DNSParseError> ParseResourceRecord(std::span<const 
 	parsed_record.q_type = static_cast<DnsQType>(rte_be_to_cpu_16(response->type));
 	parsed_record.ttl = rte_be_to_cpu_32(response->ttl);
 
-	auto rdata_bytes = std::span(reader, rte_be_to_cpu_16(response->data_len));
-
-	// Make sure that the rdata bytes area doesn't go outside the packet byte area
-	if (rdata_bytes.end() > bytes.end()) [[unlikely]]
+	// std::span(it, n) requires [it, it+n) to be a valid range.
+	const uint16_t data_len = rte_be_to_cpu_16(response->data_len);
+	const size_t remaining = static_cast<size_t>(bytes.end() - reader);
+	if (data_len > remaining) [[unlikely]]
 		return tl::unexpected(DNSParseError::OutOfBounds);
+
+	auto rdata_bytes = std::span(reader, data_len);
 
 	auto begin = reader;
 	switch (parsed_record.q_type) {

--- a/src/dns_packet.cpp
+++ b/src/dns_packet.cpp
@@ -58,6 +58,7 @@ auto fmt::formatter<DNSParseError>::format(DNSParseError e, format_context &ctx)
 			break;
 		case DNSParseError::EtherHdrProtoErr:
 			error = "ethernet header error";
+			break;
 		case DNSParseError::InvalidChar:
 			error = "invalid character detected in packet";
 			break;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -24,6 +24,9 @@
 #include "network_types.h"
 #include "scanner_config.h"
 
+// Larger than any sane DNS/UDP response; guards against bogus mbuf data_len.
+static constexpr uint16_t MAX_SANE_PKT_LEN = 4096;
+
 struct RequestContainer {
 	RequestContainer()
 	    : ready_for_send_node(this), timeout_node(this), request(std::nullopt) { }
@@ -324,6 +327,13 @@ void RX(WorkerContext &ctx, NICType &rxtx_if, uint16_t worker_id, WorkerParams &
 			RTE_MBUF_F_RX_IP_CKSUM_BAD ||
 		    (p->get().ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_BAD)
 			continue;
+
+		// Reject obviously-wrong data_len before parse or hex-dump.
+		if (p->get().data_len == 0 || p->get().data_len > MAX_SANE_PKT_LEN)
+		    [[unlikely]] {
+			param.counters[worker_id].parse_fail++;
+			continue;
+		}
 
 		auto parsed_packet = ({
 			auto res = DNSPacket::init(param.raw_mempool, *p);

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -242,6 +242,13 @@ void HandleParsedPacket(WorkerContext &ctx, WorkerParams &param, const DNSPacket
 		return;
 	}
 
+	// IPv6 src would make std::get<InAddr> throw std::bad_variant_access.
+	if (!std::holds_alternative<InAddr>(pkt.ip_data.src_ip)) [[unlikely]] {
+		spdlog::warn("packet with name {} has non-IPv4 src, dropping",
+		    pkt.question);
+		return;
+	}
+
 	if (request_container.resolver.s_addr != std::get<InAddr>(pkt.ip_data.src_ip).s_addr)
 	    [[unlikely]] {
 		spdlog::warn("packet with name {} has IP mismatch!", pkt.question);

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -389,7 +389,8 @@ void RX(WorkerContext &ctx, NICType &rxtx_if, uint16_t worker_id, WorkerParams &
 				auto dns_push = dns_dist.push(std::move(wrapped_packet));
 				if (dns_push)
 					spdlog::warn("worker {}: distribution buffer is full, "
-						     "dropping packet");
+						     "dropping packet",
+					    worker_id);
 
 				continue;
 			}

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <stack>
 #include <tuple>
+#include <unordered_set>
 #include <variant>
 
 #include "dns_format.h"
@@ -54,6 +55,11 @@ struct WorkerContext {
 			ctx.pkt_distributors.emplace_back(std::move(dns_array));
 		}
 
+		// Container resolver is rotated on retransmit; accept replies
+		// from any configured resolver.
+		for (const InAddr &r : param.resolvers)
+			ctx.resolver_set.insert(r.s_addr);
+
 		return ctx;
 	}
 
@@ -70,6 +76,7 @@ struct WorkerContext {
 	    std::vector<RequestContainer *, RteAllocator<RequestContainer *>>>
 	    available_container_stack;
 	std::vector<RTEMbufArray<DNSPacketDistr, RX_PKT_BURST>> pkt_distributors;
+	std::unordered_set<uint32_t> resolver_set;
 
 private:
 	WorkerContext(uint16_t worker_id, const WorkerParams &param)
@@ -249,9 +256,10 @@ void HandleParsedPacket(WorkerContext &ctx, WorkerParams &param, const DNSPacket
 		return;
 	}
 
-	if (request_container.resolver.s_addr != std::get<InAddr>(pkt.ip_data.src_ip).s_addr)
-	    [[unlikely]] {
-		spdlog::warn("packet with name {} has IP mismatch!", pkt.question);
+	const uint32_t pkt_src = std::get<InAddr>(pkt.ip_data.src_ip).s_addr;
+	if (!ctx.resolver_set.contains(pkt_src)) [[unlikely]] {
+		spdlog::warn("packet with name {} from unknown src, dropping",
+		    pkt.question);
 		return;
 	}
 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -429,8 +429,15 @@ void RX(WorkerContext &ctx, NICType &rxtx_if, uint16_t worker_id, WorkerParams &
 	// Dequeue all outstanding packets and continue packet receive process.
 	auto &dns_ring = param.distribution_rings[worker_id];
 	auto rx_dns = dns_ring.dequeue_burst<RX_PKT_BURST>();
-	for (auto &p : rx_dns)
+	for (auto &p : rx_dns) {
+		// Re-check worker_id after ring transit.
+		if (p.dns_packet.GetWorkerId() != worker_id) [[unlikely]] {
+			spdlog::warn("worker {}: ring delivered pkt with worker_id {}",
+			    worker_id, p.dns_packet.GetWorkerId());
+			continue;
+		}
 		HandleParsedPacket(ctx, param, p.dns_packet, p.raw_packet.get(), out_logger);
+	}
 }
 
 int Worker(std::stop_token stop_token, uint16_t worker_id, WorkerParams param) {

--- a/test/dns_packet_constructor_test.cc
+++ b/test/dns_packet_constructor_test.cc
@@ -150,8 +150,8 @@ size_t ConstructExamplePacketIpv6(RTEMbuf<DefaultPacket>& pkt) {
 	in6_addr src_addr = {{SRC_IP_IPV6}};
 	in6_addr dst_addr = {{DST_IP_IPV6}};
 
-	memcpy(ip_hdr->src_addr, &src_addr, sizeof(in6_addr));
-	memcpy(ip_hdr->dst_addr, &dst_addr, sizeof(in6_addr));
+	memcpy(&ip_hdr->src_addr, &src_addr, sizeof(in6_addr));
+	memcpy(&ip_hdr->dst_addr, &dst_addr, sizeof(in6_addr));
 
 	udp_hdr->dst_port = rte_cpu_to_be_16(53);
 	udp_hdr->src_port = rte_cpu_to_be_16(SRC_PORT);

--- a/test/dns_packet_test.cc
+++ b/test/dns_packet_test.cc
@@ -9,6 +9,7 @@
 #include <glaze/glaze.hpp>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -810,4 +811,104 @@ TEST(DnsPacketParserTest, OutOfBoundsTrunc) {
 	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
 	EXPECT_EQ(parsed_packet.has_value(), false);
 	EXPECT_EQ(parsed_packet.error(), DNSParseError::OutOfBounds);
+}
+
+// Zero-filled frame: ether_type 0 is neither IPv4 nor IPv6.
+TEST(DnsPacketParserTest, ZeroFilledFrameReportsEtherError) {
+	auto test_packet = TestPacket{.raw = std::string(128, '\0')};
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_FALSE(parsed_packet.has_value());
+	EXPECT_EQ(parsed_packet.error(), DNSParseError::EtherHdrProtoErr);
+
+	EXPECT_EQ(fmt::format("{}", DNSParseError::EtherHdrProtoErr),
+	    "ethernet header error");
+	EXPECT_EQ(fmt::format("{}", DNSParseError::InvalidChar),
+	    "invalid character detected in packet");
+}
+
+// Answer RData.data_len claims 256 bytes, only 2 follow.
+TEST(DnsPacketParserTest, TruncatedRdataLenBoundsChecked) {
+	auto test_packet = TestPacket{
+	    .raw = "\xbc\xd0\x74\x17\xbe\x44\x30\xde\x4b\xac\x03\x7c\x08\x00\x45\x00"
+		   "\x00\x33\x00\x01\x00\x00\x40\x11\x00\x00\xc0\xa8\x00\x01\xc0\xa8"
+		   "\x00\x02\x00\x35\xce\x31\x00\x1f\x00\x00\xd3\x4d\x81\x80\x00\x01"
+		   "\x00\x01\x00\x00\x00\x00\x01\x61\x00\x00\x01\x00\x01"
+		   "\xc0\x0c\x00\x01\x00\x01\x00\x00\x00\x3c\x01\x00\x01\x02"s};
+
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_FALSE(parsed_packet.has_value());
+	EXPECT_EQ(parsed_packet.error(), DNSParseError::OutOfBounds);
+}
+
+// Ethertype == IPv6 with no IPv6 header payload.
+TEST(DnsPacketParserTest, Ipv6HeaderTruncated) {
+	auto test_packet =
+	    TestPacket{.raw = "\xbc\xd0\x74\x17\xbe\x44\x30\xde\x4b\xac\x03\x7c\x86\xdd"s};
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_FALSE(parsed_packet.has_value());
+	EXPECT_EQ(parsed_packet.error(), DNSParseError::OutOfBounds);
+}
+
+// Empty mbuf.
+TEST(DnsPacketParserTest, EmptyFrameIsRejected) {
+	auto test_packet = TestPacket{.raw = ""s};
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_FALSE(parsed_packet.has_value());
+	EXPECT_EQ(parsed_packet.error(), DNSParseError::OutOfBounds);
+}
+
+// UDP src port != 53.
+TEST(DnsPacketParserTest, NonDnsSourcePortRejected) {
+	auto test_packet = TestPacket{
+	    .raw = "\xbc\xd0\x74\x17\xbe\x44\x30\xde\x4b\xac\x03\x7c\x08\x00\x45\x00"
+		   "\x00\x20\x00\x01\x00\x00\x40\x11\x00\x00\xc0\xa8\x00\x01\xc0\xa8"
+		   "\x00\x02\x00\x01\xce\x31\x00\x0c\x00\x00"s};
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_FALSE(parsed_packet.has_value());
+	EXPECT_EQ(parsed_packet.error(), DNSParseError::SrcPortErr);
+}
+
+// IPv6 reply must land in the In6Addr arm; std::get<InAddr> on that
+// variant must throw. Together these pin the contract worker.cpp's
+// std::holds_alternative<InAddr> guard relies on.
+TEST(DnsPacketIpVariantRegression, Ipv6SrcLandsInV6Arm) {
+	auto test_packet = TestPacket{
+	    .raw = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x86\xdd"
+		   "\x60\x00\x00\x00\x00\x15\x11\x40"
+		   "\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
+		   "\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02"
+		   "\x00\x35\x30\x39\x00\x15\x00\x00"
+		   "\x00\x01\x81\x80\x00\x01\x00\x00\x00\x00\x00\x00"
+		   "\x01\x61\x00\x00\x01\x00\x01"s,
+	    .ip_type = PacketIpType::Ipv6};
+
+	auto [mbuf_pool_out, parsed_packet] = ExtractPacket(test_packet);
+	ASSERT_TRUE(parsed_packet.has_value());
+
+	EXPECT_TRUE(std::holds_alternative<In6Addr>(parsed_packet->ip_data.src_ip));
+	EXPECT_FALSE(std::holds_alternative<InAddr>(parsed_packet->ip_data.src_ip));
+
+	EXPECT_THROW(
+	    { std::ignore = std::get<InAddr>(parsed_packet->ip_data.src_ip); },
+	    std::bad_variant_access);
+}
+
+// Reply is accepted from any configured resolver, not just the current one.
+TEST(WorkerResolverSetRegression, AcceptsAnyConfiguredResolver) {
+	std::unordered_set<uint32_t> resolver_set;
+	for (const auto &ip : {"10.0.0.1", "10.0.0.2", "10.0.0.3"}) {
+		auto addr = InAddr::init(ip);
+		ASSERT_TRUE(addr.has_value());
+		resolver_set.insert(addr->s_addr);
+	}
+
+	for (const auto &ip : {"10.0.0.1", "10.0.0.2", "10.0.0.3"}) {
+		auto addr = InAddr::init(ip);
+		ASSERT_TRUE(addr.has_value());
+		EXPECT_TRUE(resolver_set.contains(addr->s_addr)) << "for " << ip;
+	}
+
+	auto foreign = InAddr::init("8.8.8.8");
+	ASSERT_TRUE(foreign.has_value());
+	EXPECT_FALSE(resolver_set.contains(foreign->s_addr));
 }


### PR DESCRIPTION
std::get<InAddr> on an IPv6 reply -> bad_variant_access. Guarded it,
plus the surrounding mess:

- worker: variant guard; accept any configured resolver; drop bogus
  mbufs (data_len 0 or >4 KiB); re-check worker_id after ring transit;
  fix spdlog format-arg miscount

- dns_packet: missing break in fmt formatter; bounds-check RData
  before std::span ctor

- dpdk: address-of rte_ipv6_hdr::{src,dst}_addr for 25.11 ABI

- cmake: PMDs are optional (looking at you, [Btw](https://forum.freecad.org/viewtopic.php?t=95967))

- tests: 7 regressions

// Pepijn